### PR TITLE
Add session start hook for IDA Pro development in Claude Code web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -euo pipefail
+
+# Session start hook for IDA Pro development environment
+# This hook installs IDA Pro and idalib for Python development
+
+# Only run in Claude Code remote (web) environment
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+fi
+
+# Check for required environment variables
+if [ -z "${HCLI_API_KEY:-}" ]; then
+    echo "Warning: HCLI_API_KEY not set. IDA Pro installation will be skipped."
+    exit 0
+fi
+
+if [ -z "${IDA_LICENSE_ID:-}" ]; then
+    echo "Warning: IDA_LICENSE_ID not set. IDA Pro installation will be skipped."
+    exit 0
+fi
+
+echo "Setting up IDA Pro development environment..."
+
+# Set IDA installation directory
+IDA_INSTALL_DIR="${HOME}/.local/ida"
+
+# Export environment variables for the session
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    echo "export HCLI_DISABLE_UPDATES=1" >> "$CLAUDE_ENV_FILE"
+    echo "export IDADIR=\"${IDA_INSTALL_DIR}\"" >> "$CLAUDE_ENV_FILE"
+fi
+
+# Check if IDA is already installed (idempotent)
+if [ -d "$IDA_INSTALL_DIR" ] && [ -f "$IDA_INSTALL_DIR/idat64" ]; then
+    echo "IDA Pro already installed at ${IDA_INSTALL_DIR}"
+else
+    echo "Installing HCLI..."
+
+    # Install HCLI binary
+    curl -LsSf https://hcli.docs.hex-rays.com/install | sh
+
+    # Add HCLI to PATH for this script
+    export PATH="${HOME}/.local/bin:${PATH}"
+
+    echo "Installing IDA Pro..."
+
+    # Install IDA Pro using HCLI
+    # Using ida-essential for x64 Linux - adjust download-id as needed for your license
+    hcli ida install \
+        --download-id "release/9.2/ida-pro/ida-pro_92_x64linux.run" \
+        --license-id "${IDA_LICENSE_ID}" \
+        --install-dir "${IDA_INSTALL_DIR}" \
+        --set-default \
+        --accept-eula \
+        --yes
+
+    echo "IDA Pro installed successfully."
+fi
+
+# Install idapro Python package if not already installed
+if ! python3 -c "import idapro" 2>/dev/null; then
+    echo "Installing idapro Python package..."
+
+    # Install from PyPI
+    pip install idapro
+
+    # Activate idalib with the IDA installation
+    if [ -f "${IDA_INSTALL_DIR}/py-activate-idalib.py" ]; then
+        python3 "${IDA_INSTALL_DIR}/py-activate-idalib.py" -d "${IDA_INSTALL_DIR}"
+    elif [ -f "${IDA_INSTALL_DIR}/idalib/python/py-activate-idalib.py" ]; then
+        python3 "${IDA_INSTALL_DIR}/idalib/python/py-activate-idalib.py" -d "${IDA_INSTALL_DIR}"
+    fi
+
+    echo "idapro Python package installed and activated."
+else
+    echo "idapro Python package already installed."
+fi
+
+# Install this repository's package
+if [ -f "${CLAUDE_PROJECT_DIR:-}/setup.py" ]; then
+    echo "Installing idawilli package..."
+    pip install -e "${CLAUDE_PROJECT_DIR}"
+fi
+
+echo "IDA Pro development environment setup complete!"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -142,5 +142,8 @@ ida_ua.py
 ida_undo.py
 ida_xref.py
 __pycache__/
-.claude/
+# Claude Code - ignore user-specific files but track shared hooks
+.claude/*
+!.claude/hooks/
+!.claude/settings.json
 **/*.DS_Store

--- a/scripts/verify_idalib.py
+++ b/scripts/verify_idalib.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Verify that idalib is properly installed and configured.
+
+This script tests that:
+1. The idapro package can be imported
+2. A database can be opened and closed using open_database()
+3. Basic IDA API functions work
+
+Usage:
+    python verify_idalib.py <binary_file>
+
+Example:
+    python verify_idalib.py /bin/ls
+"""
+
+import sys
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify idalib installation")
+    parser.add_argument("file", help="Binary file to analyze")
+    parser.add_argument(
+        "--run-auto-analysis",
+        action="store_true",
+        default=False,
+        help="Run auto-analysis (slower but more complete)",
+    )
+    args = parser.parse_args()
+
+    print("Testing idalib installation...")
+
+    # Import idapro first (required by idalib)
+    try:
+        import idapro
+
+        print("  [OK] idapro package imported successfully")
+    except ImportError as e:
+        print(f"  [FAIL] Could not import idapro: {e}")
+        print("  Make sure idapro is installed: pip install idapro")
+        print("  And activated: python <IDA_DIR>/py-activate-idalib.py -d <IDA_DIR>")
+        return 1
+
+    # Open database
+    try:
+        print(f"  Opening database for: {args.file}")
+        idapro.open_database(args.file, args.run_auto_analysis)
+        print("  [OK] Database opened successfully")
+    except Exception as e:
+        print(f"  [FAIL] Could not open database: {e}")
+        return 1
+
+    # Test basic IDA API
+    try:
+        import idaapi
+        import idc
+
+        # Wait for auto-analysis if requested
+        if args.run_auto_analysis:
+            print("  Waiting for auto-analysis to complete...")
+            idaapi.auto_wait()
+
+        # Get some basic info
+        info = idaapi.get_inf_structure()
+        print(f"  [OK] File type: {info.filetype}")
+        print(f"  [OK] Processor: {info.procname}")
+        print(f"  [OK] Min EA: {hex(info.min_ea)}")
+        print(f"  [OK] Max EA: {hex(info.max_ea)}")
+    except Exception as e:
+        print(f"  [WARN] Could not query database info: {e}")
+
+    # Close database
+    try:
+        idapro.close_database(save=False)
+        print("  [OK] Database closed successfully")
+    except Exception as e:
+        print(f"  [FAIL] Could not close database: {e}")
+        return 1
+
+    print("\nidalib verification complete! All tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This adds a SessionStart hook that automatically sets up the IDA Pro
development environment when running in Claude Code on the web:

- Installs HCLI (Hex-Rays CLI) for managing IDA installations
- Downloads and installs IDA Pro using provided credentials
- Installs the idapro Python package and activates idalib
- Installs the idawilli package in development mode

Required environment variables:
- HCLI_API_KEY: API key for Hex-Rays authentication
- IDA_LICENSE_ID: License ID for IDA Pro (e.g., 96-0000-0000-01)

Also adds a verify_idalib.py script to test the idalib installation.