### PR TITLE
Fix test collection: drop --import-mode=importlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ build-backend = "hatchling.build"
 packages = ["idawilli"]
 
 [tool.pytest.ini_options]
-addopts = "--import-mode=importlib"
 testpaths = ["tests"]
 
 [tool.mypy]


### PR DESCRIPTION
The root pytest config set `--import-mode=importlib`, under which pytest
no longer prepends each test file's directory to sys.path. That broke
`from conftest import run_ida_script` in the oplog and global-struct
dissector suites, causing `ModuleNotFoundError: No module named 'conftest'`
at collection time and failing those workflows on master.

Reverting to the default prepend import mode restores the sibling-module
imports these suites rely on.

https://claude.ai/code/session_016xp2mUF1gnPDvGy2jeFqEg