### PR TITLE
fix: remove unused type-ignore directives in ida-codemode-api

### DIFF
--- a/ida-codemode/packages/ida-codemode-api/ida_codemode_api/api.py
+++ b/ida-codemode/packages/ida-codemode-api/ida_codemode_api/api.py
@@ -889,7 +889,7 @@ def create_api_from_database(db: Any) -> api_types.ApiFunctions:
                 results = []
 
         try:
-            import ida_nalt  # type: ignore
+            import ida_nalt
         except Exception as exc:
             if db_imports_error is not None:
                 return _error(
@@ -1225,8 +1225,8 @@ def create_api_from_database(db: Any) -> api_types.ApiFunctions:
             if "(" in type_str and name not in type_str:
                 type_str = type_str.replace("(", f" {name}(", 1)
 
-            tif = ida_typeinf.tinfo_t()  # ty: ignore[missing-argument]
-            parse_result = ida_typeinf.parse_decl(tif, None, type_str, 0)  # ty: ignore[invalid-argument-type]
+            tif = ida_typeinf.tinfo_t()
+            parse_result = ida_typeinf.parse_decl(tif, None, type_str, 0)
             if not parse_result:
                 return _error(f"failed to parse type declaration: {type_str}")
 
@@ -1376,8 +1376,8 @@ def create_api_from_database(db: Any) -> api_types.ApiFunctions:
 
         try:
             type_str = type
-            tinfo = ida_typeinf.tinfo_t()  # ty: ignore[missing-argument]
-            if not ida_typeinf.parse_decl(tinfo, None, type_str, ida_typeinf.PT_SIL):  # ty: ignore[invalid-argument-type]
+            tinfo = ida_typeinf.tinfo_t()
+            if not ida_typeinf.parse_decl(tinfo, None, type_str, ida_typeinf.PT_SIL):
                 return _error(f"failed to parse type string {type_str!r}")
 
             lvar = matching_vars[0]


### PR DESCRIPTION
## Summary

- Remove `# type: ignore` from `import ida_nalt` (line 892) -- ty can now resolve this via the venv's `idapro` package
- Remove `# ty: ignore[missing-argument]` and `# ty: ignore[invalid-argument-type]` from `ida_typeinf.tinfo_t()` and `ida_typeinf.parse_decl()` calls (lines 1228-1229, 1379-1380) -- same reason

These became unnecessary after the `--python` flag was added to `ty check` in CI, which lets ty resolve packages from the venv. The warnings cause CI to fail because `ty check` exits non-zero.

## Test plan

- [ ] CI `ida-codemode-api checks` workflow passes (lint step: `ty check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)