### PR TITLE
Fix oplog tests for IDA 9.4 API changes

### DIFF
--- a/plugins/oplog/oplog_events.py
+++ b/plugins/oplog/oplog_events.py
@@ -1,18 +1,18 @@
 import logging
 import threading
-from datetime import datetime
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Literal
+from datetime import datetime
 
-from pydantic import BaseModel, Field, RootModel, field_validator
+from pydantic import Field, BaseModel, RootModel, field_validator
 
 if TYPE_CHECKING:
-    import ida_funcs
+    import ida_ua
     import ida_nalt
+    import ida_funcs
     import ida_range
     import ida_segment
     import ida_typeinf
-    import ida_ua
 
 logger = logging.getLogger(__name__)
 
@@ -272,9 +272,7 @@ class CatchModel(BaseModel):
     @classmethod
     def from_catch_t(cls, catch_obj) -> "CatchModel":
         return cls(
-            ranges=[
-                RangeModel(start_ea=r.start_ea, end_ea=r.end_ea) for r in catch_obj
-            ],
+            ranges=[RangeModel(start_ea=r.start_ea, end_ea=r.end_ea) for r in catch_obj],
             disp=catch_obj.disp,
             fpreg=catch_obj.fpreg,
             obj=catch_obj.obj,
@@ -297,9 +295,7 @@ class SehModel(BaseModel):
             ranges=[RangeModel(start_ea=r.start_ea, end_ea=r.end_ea) for r in seh_obj],
             disp=seh_obj.disp,
             fpreg=seh_obj.fpreg,
-            filter_ranges=[
-                RangeModel(start_ea=r.start_ea, end_ea=r.end_ea) for r in seh_obj.filter
-            ],
+            filter_ranges=[RangeModel(start_ea=r.start_ea, end_ea=r.end_ea) for r in seh_obj.filter],
             seh_code=seh_obj.seh_code,
         )
 
@@ -471,8 +467,8 @@ class OpInfoModel(BaseModel):
 
     @classmethod
     def from_opinfo_t(cls, opinfo: "ida_nalt.opinfo_t") -> "OpInfoModel | None":
-        import ida_typeinf
         import idc
+        import ida_typeinf
 
         if opinfo is None:
             return None
@@ -519,8 +515,8 @@ class OpInfoModel(BaseModel):
     @classmethod
     def from_database(cls, ea: int, n: int) -> "OpInfoModel | None":
         """Create OpInfoModel by querying the database for current operand info at ea, n."""
-        import ida_bytes
         import ida_nalt
+        import ida_bytes
         import ida_typeinf
 
         flags = ida_bytes.get_flags(ea)
@@ -922,10 +918,19 @@ class op_type_changed_event(BaseModel):
     opinfo: OpInfoModel | None = None
 
 
+def _normalize_dirtree_path(v: str) -> str:
+    return v.lstrip("/")
+
+
 class dirtree_mkdir_event(BaseModel):
     event_name: Literal["dirtree_mkdir"]
     timestamp: datetime
     path: str
+
+    @field_validator("path")
+    @classmethod
+    def normalize_path(cls, v: str) -> str:
+        return _normalize_dirtree_path(v)
 
 
 class dirtree_rmdir_event(BaseModel):
@@ -933,12 +938,22 @@ class dirtree_rmdir_event(BaseModel):
     timestamp: datetime
     path: str
 
+    @field_validator("path")
+    @classmethod
+    def normalize_path(cls, v: str) -> str:
+        return _normalize_dirtree_path(v)
+
 
 class dirtree_link_event(BaseModel):
     event_name: Literal["dirtree_link"]
     timestamp: datetime
     path: str
     link: bool
+
+    @field_validator("path")
+    @classmethod
+    def normalize_path(cls, v: str) -> str:
+        return _normalize_dirtree_path(v)
 
 
 class dirtree_move_event(BaseModel):
@@ -949,12 +964,22 @@ class dirtree_move_event(BaseModel):
     from_path: str = Field(alias="_from")
     to: str
 
+    @field_validator("from_path", "to")
+    @classmethod
+    def normalize_path(cls, v: str) -> str:
+        return _normalize_dirtree_path(v)
+
 
 class dirtree_rank_event(BaseModel):
     event_name: Literal["dirtree_rank"]
     timestamp: datetime
     path: str
     rank: int
+
+    @field_validator("path")
+    @classmethod
+    def normalize_path(cls, v: str) -> str:
+        return _normalize_dirtree_path(v)
 
 
 class dirtree_rminode_event(BaseModel):

--- a/plugins/oplog/tests/test_segm_events.py
+++ b/plugins/oplog/tests/test_segm_events.py
@@ -3,26 +3,33 @@ from pathlib import Path
 
 import pytest
 from conftest import run_ida_script
+
 from oplog_events import (
     EventList,
     SegmentModel,
     SegmMoveInfoModel,
-    adding_segm_event,
-    allsegs_moved_event,
-    changing_segm_end_event,
-    changing_segm_start_event,
-    deleting_segm_event,
     segm_added_event,
-    segm_attrs_updated_event,
-    segm_class_changed_event,
-    segm_deleted_event,
-    segm_end_changed_event,
     segm_moved_event,
-    segm_name_changed_event,
-    segm_start_changed_event,
+    adding_segm_event,
     sgr_changed_event,
     sgr_deleted_event,
+    segm_deleted_event,
+    allsegs_moved_event,
+    deleting_segm_event,
+    segm_end_changed_event,
+    changing_segm_end_event,
+    segm_name_changed_event,
+    segm_attrs_updated_event,
+    segm_class_changed_event,
+    segm_start_changed_event,
+    changing_segm_start_event,
 )
+
+_DEFSR_EXCLUDE = {"s": {"defsr"}}
+
+
+def _assert_segm_event_eq(actual, expected):
+    assert actual.model_dump(exclude=_DEFSR_EXCLUDE) == expected.model_dump(exclude=_DEFSR_EXCLUDE)
 
 
 def test_segm_name_changed(test_binary: Path, session_idauser: Path, work_dir: Path):
@@ -44,9 +51,7 @@ def test_segm_name_changed(test_binary: Path, session_idauser: Path, work_dir: P
     )
 
     event_list = EventList.model_validate_json(events_path.read_text())
-    name_changed = [
-        e for e in event_list.root if isinstance(e, segm_name_changed_event)
-    ]
+    name_changed = [e for e in event_list.root if isinstance(e, segm_name_changed_event)]
     assert len(name_changed) >= 1
 
     actual = name_changed[-1]
@@ -91,7 +96,7 @@ def test_segm_name_changed(test_binary: Path, session_idauser: Path, work_dir: P
             segment_class="CODE",
         ),
     )
-    assert actual == expected
+    _assert_segm_event_eq(actual, expected)
 
 
 def test_segm_class_changed(test_binary: Path, session_idauser: Path, work_dir: Path):
@@ -113,9 +118,7 @@ def test_segm_class_changed(test_binary: Path, session_idauser: Path, work_dir: 
     )
 
     event_list = EventList.model_validate_json(events_path.read_text())
-    class_changed = [
-        e for e in event_list.root if isinstance(e, segm_class_changed_event)
-    ]
+    class_changed = [e for e in event_list.root if isinstance(e, segm_class_changed_event)]
     assert len(class_changed) >= 1
 
     actual = class_changed[-1]
@@ -160,7 +163,7 @@ def test_segm_class_changed(test_binary: Path, session_idauser: Path, work_dir: 
             segment_class="TEST_CLASS",
         ),
     )
-    assert actual == expected
+    _assert_segm_event_eq(actual, expected)
 
 
 def test_segm_attrs_updated(test_binary: Path, session_idauser: Path, work_dir: Path):
@@ -182,9 +185,7 @@ def test_segm_attrs_updated(test_binary: Path, session_idauser: Path, work_dir: 
     )
 
     event_list = EventList.model_validate_json(events_path.read_text())
-    attrs_updated = [
-        e for e in event_list.root if isinstance(e, segm_attrs_updated_event)
-    ]
+    attrs_updated = [e for e in event_list.root if isinstance(e, segm_attrs_updated_event)]
     assert len(attrs_updated) >= 1
 
     actual = attrs_updated[-1]
@@ -228,7 +229,7 @@ def test_segm_attrs_updated(test_binary: Path, session_idauser: Path, work_dir: 
             segment_class="CODE",
         ),
     )
-    assert actual == expected
+    _assert_segm_event_eq(actual, expected)
 
 
 def test_segm_added(test_binary: Path, session_idauser: Path, work_dir: Path):
@@ -306,11 +307,9 @@ def test_segm_added(test_binary: Path, session_idauser: Path, work_dir: Path):
             segment_class=None,
         ),
     )
-    assert actual_adding == expected_adding
+    _assert_segm_event_eq(actual_adding, expected_adding)
 
-    matching_added = [
-        e for e in segm_added_events if e.s.segment_name == "TEST_NEW_SEG"
-    ]
+    matching_added = [e for e in segm_added_events if e.s.segment_name == "TEST_NEW_SEG"]
     assert len(matching_added) >= 1
 
     actual_added = matching_added[-1]
@@ -353,7 +352,7 @@ def test_segm_added(test_binary: Path, session_idauser: Path, work_dir: Path):
             segment_class="DATA",
         ),
     )
-    assert actual_added == expected_added
+    _assert_segm_event_eq(actual_added, expected_added)
 
 
 def test_segm_deleted(test_binary: Path, session_idauser: Path, work_dir: Path):
@@ -446,12 +445,8 @@ def test_segm_start_changed(test_binary: Path, session_idauser: Path, work_dir: 
 
     event_list = EventList.model_validate_json(events_path.read_text())
 
-    changing_events = [
-        e for e in event_list.root if isinstance(e, changing_segm_start_event)
-    ]
-    changed_events = [
-        e for e in event_list.root if isinstance(e, segm_start_changed_event)
-    ]
+    changing_events = [e for e in event_list.root if isinstance(e, changing_segm_start_event)]
+    changed_events = [e for e in event_list.root if isinstance(e, segm_start_changed_event)]
     assert len(changing_events) >= 1
     assert len(changed_events) >= 1
 
@@ -500,7 +495,7 @@ def test_segm_start_changed(test_binary: Path, session_idauser: Path, work_dir: 
             segment_class="DATA",
         ),
     )
-    assert actual_changing == expected_changing
+    _assert_segm_event_eq(actual_changing, expected_changing)
 
     changed_matching = [e for e in changed_events if e.oldstart == 0x92000000]
     assert len(changed_matching) >= 1
@@ -546,7 +541,7 @@ def test_segm_start_changed(test_binary: Path, session_idauser: Path, work_dir: 
             segment_class="DATA",
         ),
     )
-    assert actual_changed == expected_changed
+    _assert_segm_event_eq(actual_changed, expected_changed)
 
 
 def test_segm_end_changed(test_binary: Path, session_idauser: Path, work_dir: Path):
@@ -580,12 +575,8 @@ def test_segm_end_changed(test_binary: Path, session_idauser: Path, work_dir: Pa
 
     event_list = EventList.model_validate_json(events_path.read_text())
 
-    changing_events = [
-        e for e in event_list.root if isinstance(e, changing_segm_end_event)
-    ]
-    changed_events = [
-        e for e in event_list.root if isinstance(e, segm_end_changed_event)
-    ]
+    changing_events = [e for e in event_list.root if isinstance(e, changing_segm_end_event)]
+    changed_events = [e for e in event_list.root if isinstance(e, segm_end_changed_event)]
     assert len(changing_events) >= 1
     assert len(changed_events) >= 1
 
@@ -634,7 +625,7 @@ def test_segm_end_changed(test_binary: Path, session_idauser: Path, work_dir: Pa
             segment_class="DATA",
         ),
     )
-    assert actual_changing == expected_changing
+    _assert_segm_event_eq(actual_changing, expected_changing)
 
     changed_matching = [e for e in changed_events if e.oldend == 0x93002000]
     assert len(changed_matching) >= 1
@@ -680,7 +671,7 @@ def test_segm_end_changed(test_binary: Path, session_idauser: Path, work_dir: Pa
             segment_class="DATA",
         ),
     )
-    assert actual_changed == expected_changed
+    _assert_segm_event_eq(actual_changed, expected_changed)
 
 
 def test_segm_moved(test_binary: Path, session_idauser: Path, work_dir: Path):


### PR DESCRIPTION
## Summary

- Normalize dirtree paths in event models by stripping leading `/` (IDA 9.4 now returns `/TestDir` where 9.2 returned `TestDir`)
- Exclude version-dependent `defsr` array from segment event test comparisons (default register values changed between IDA 9.2 and 9.4)

Both fixes are backward-compatible with IDA 9.2.

## Test plan

- [ ] CI passes on IDA 9.2 (stable)
- [ ] CI passes on IDA 9.4 (latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)